### PR TITLE
Add emoji picker in "Manage Squad" view

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -78,7 +78,28 @@
                     <form id="add-agent-form">
                         <input type="text" id="agent-name" placeholder="Agent Name" required>
                         <input type="text" id="agent-role" placeholder="Role" required>
-                        <input type="text" id="agent-emoji" placeholder="Emoji (e.g., 🤖)" required maxlength="2">
+                        <select id="agent-emoji" required>
+                            <option value="🤖">🤖 Robot</option>
+                            <option value="🏗️">🏗️ Construction</option>
+                            <option value="⚛️">⚛️ Atom</option>
+                            <option value="⚙️">⚙️ Gear</option>
+                            <option value="🔬">🔬 Microscope</option>
+                            <option value="🎯">🎯 Target</option>
+                            <option value="🛡️">🛡️ Shield</option>
+                            <option value="🧠">🧠 Brain</option>
+                            <option value="💡">💡 Lightbulb</option>
+                            <option value="🔍">🔍 Search</option>
+                            <option value="📊">📊 Chart</option>
+                            <option value="🚀">🚀 Rocket</option>
+                            <option value="🦊">🦊 Fox</option>
+                            <option value="🐙">🐙 Octopus</option>
+                            <option value="🦉">🦉 Owl</option>
+                            <option value="🎨">🎨 Palette</option>
+                            <option value="📝">📝 Memo</option>
+                            <option value="⚡">⚡ Lightning</option>
+                            <option value="🔧">🔧 Wrench</option>
+                            <option value="🌐">🌐 Globe</option>
+                        </select>
                         <button type="submit" class="btn-primary">Add Agent</button>
                     </form>
                 </div>

--- a/public/index.html
+++ b/public/index.html
@@ -79,26 +79,6 @@
                         <input type="text" id="agent-name" placeholder="Agent Name" required>
                         <input type="text" id="agent-role" placeholder="Role" required>
                         <select id="agent-emoji" required>
-                            <option value="🤖">🤖 Robot</option>
-                            <option value="🏗️">🏗️ Construction</option>
-                            <option value="⚛️">⚛️ Atom</option>
-                            <option value="⚙️">⚙️ Gear</option>
-                            <option value="🔬">🔬 Microscope</option>
-                            <option value="🎯">🎯 Target</option>
-                            <option value="🛡️">🛡️ Shield</option>
-                            <option value="🧠">🧠 Brain</option>
-                            <option value="💡">💡 Lightbulb</option>
-                            <option value="🔍">🔍 Search</option>
-                            <option value="📊">📊 Chart</option>
-                            <option value="🚀">🚀 Rocket</option>
-                            <option value="🦊">🦊 Fox</option>
-                            <option value="🐙">🐙 Octopus</option>
-                            <option value="🦉">🦉 Owl</option>
-                            <option value="🎨">🎨 Palette</option>
-                            <option value="📝">📝 Memo</option>
-                            <option value="⚡">⚡ Lightning</option>
-                            <option value="🔧">🔧 Wrench</option>
-                            <option value="🌐">🌐 Globe</option>
                         </select>
                         <button type="submit" class="btn-primary">Add Agent</button>
                     </form>

--- a/public/index.html
+++ b/public/index.html
@@ -78,8 +78,11 @@
                     <form id="add-agent-form">
                         <input type="text" id="agent-name" placeholder="Agent Name" required>
                         <input type="text" id="agent-role" placeholder="Role" required>
+                        <div class="form-field">
+                        <label for="agent-emoji">Agent emoji</label>
                         <select id="agent-emoji" required>
                         </select>
+                        </div>
                         <button type="submit" class="btn-primary">Add Agent</button>
                     </form>
                 </div>

--- a/public/renderer.js
+++ b/public/renderer.js
@@ -227,7 +227,20 @@ function renderRosterList() {
 
 async function initialize() {
     try {
-        agents = await window.squadAPI.getAgents();
+        const [fetchedAgents, emojisResult] = await Promise.all([
+            window.squadAPI.getAgents(),
+            window.squadAPI.getEmojis().catch(() => [{ emoji: '🤖', label: 'Robot' }]),
+        ]);
+        agents = fetchedAgents;
+
+        const emojiSelect = document.getElementById('agent-emoji');
+        const emojiList = emojisResult.length > 0 ? emojisResult : [{ emoji: '🤖', label: 'Robot' }];
+        emojiList.forEach(({ emoji, label }) => {
+            const option = document.createElement('option');
+            option.value = emoji;
+            option.textContent = `${emoji} ${label}`;
+            emojiSelect.appendChild(option);
+        });
         renderAgentsList();
         updateAgentSelector();
         renderAllQueues();

--- a/public/renderer.js
+++ b/public/renderer.js
@@ -1,13 +1,13 @@
 let agents = [];
 let terminalLogCount = 0;
 
-function escapeHtml(str) {
+function escapeHTML(str) {
     return String(str)
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
         .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#x27;');
+        .replace(/'/g, '&#39;');
 }
 
 function formatTimestamp(date) {
@@ -33,12 +33,12 @@ function renderAgentCard(agent) {
         <div class="agent-header">
             <div class="agent-emoji">${agent.emoji}</div>
             <div class="agent-info">
-                <div class="agent-name">${escapeHtml(agent.name)}</div>
-                <div class="agent-role">${escapeHtml(agent.role)}</div>
+                <div class="agent-name">${escapeHTML(agent.name)}</div>
+                <div class="agent-role">${escapeHTML(agent.role)}</div>
             </div>
             <span class="status-badge ${statusClass}">${agent.status}</span>
         </div>
-        <div class="agent-output" title="Click to expand/collapse">${outputText}</div>
+        <div class="agent-output" title="Click to expand/collapse">${escapeHTML(outputText)}</div>
     `;
 
     return card;
@@ -139,9 +139,9 @@ function renderQueueItem(queueItem, agentName, agentEmoji) {
             <span class="queue-status ${statusClass}">${queueItem.status}</span>
             <span class="queue-timestamp">${timestamp}</span>
         </div>
-        <div class="queue-command">${queueItem.command}</div>
-        <div class="queue-agent">→ ${agentEmoji} ${escapeHtml(agentName)}</div>
-        ${resultPreview ? `<div class="queue-result">${resultPreview}</div>` : ''}
+        <div class="queue-command">${escapeHTML(queueItem.command)}</div>
+        <div class="queue-agent">→ ${agentEmoji} ${escapeHTML(agentName)}</div>
+        ${resultPreview ? `<div class="queue-result">${escapeHTML(resultPreview)}</div>` : ''}
     `;
 
     return card;
@@ -200,8 +200,8 @@ function renderRosterList() {
             <div class="roster-item-info">
                 <div class="roster-item-emoji">${agent.emoji}</div>
                 <div class="roster-item-details">
-                    <div class="roster-item-name">${escapeHtml(agent.name)}</div>
-                    <div class="roster-item-role">${escapeHtml(agent.role)}</div>
+                    <div class="roster-item-name">${escapeHTML(agent.name)}</div>
+                    <div class="roster-item-role">${escapeHTML(agent.role)}</div>
                 </div>
             </div>
             <button class="btn-remove" data-agent-id="${agent.id}">Remove</button>

--- a/public/renderer.js
+++ b/public/renderer.js
@@ -1,6 +1,15 @@
 let agents = [];
 let terminalLogCount = 0;
 
+function escapeHtml(str) {
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#x27;');
+}
+
 function formatTimestamp(date) {
     const hours = date.getHours();
     const minutes = date.getMinutes();
@@ -24,8 +33,8 @@ function renderAgentCard(agent) {
         <div class="agent-header">
             <div class="agent-emoji">${agent.emoji}</div>
             <div class="agent-info">
-                <div class="agent-name">${agent.name}</div>
-                <div class="agent-role">${agent.role}</div>
+                <div class="agent-name">${escapeHtml(agent.name)}</div>
+                <div class="agent-role">${escapeHtml(agent.role)}</div>
             </div>
             <span class="status-badge ${statusClass}">${agent.status}</span>
         </div>
@@ -131,7 +140,7 @@ function renderQueueItem(queueItem, agentName, agentEmoji) {
             <span class="queue-timestamp">${timestamp}</span>
         </div>
         <div class="queue-command">${queueItem.command}</div>
-        <div class="queue-agent">→ ${agentEmoji} ${agentName}</div>
+        <div class="queue-agent">→ ${agentEmoji} ${escapeHtml(agentName)}</div>
         ${resultPreview ? `<div class="queue-result">${resultPreview}</div>` : ''}
     `;
 
@@ -191,8 +200,8 @@ function renderRosterList() {
             <div class="roster-item-info">
                 <div class="roster-item-emoji">${agent.emoji}</div>
                 <div class="roster-item-details">
-                    <div class="roster-item-name">${agent.name}</div>
-                    <div class="roster-item-role">${agent.role}</div>
+                    <div class="roster-item-name">${escapeHtml(agent.name)}</div>
+                    <div class="roster-item-role">${escapeHtml(agent.role)}</div>
                 </div>
             </div>
             <button class="btn-remove" data-agent-id="${agent.id}">Remove</button>

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,6 +1,6 @@
 // Service worker — cache-first for app shell, network-first for API calls.
 
-const CACHE_NAME = 'squad-desktop-v1';
+const CACHE_NAME = 'squad-desktop-v3';
 const APP_SHELL = [
   '/',
   '/index.html',

--- a/public/squadAPI.js
+++ b/public/squadAPI.js
@@ -104,6 +104,10 @@
   var _state = window.__SQUAD_STATE__ || { agents: [], connectionState: 'disconnected' };
 
   window.squadAPI = {
+    getEmojis: NATIVE
+      ? function () { return Promise.resolve(_state.emojis || []); }
+      : function () { return fetchJSON('/api/emojis'); },
+
     getAgents: NATIVE
       ? function () { return Promise.resolve(_state.agents); }
       : function () { return fetchJSON('/api/agents'); },

--- a/public/styles.css
+++ b/public/styles.css
@@ -549,6 +549,17 @@ body {
     gap: 12px;
 }
 
+#add-agent-form label {
+    font-size: 13px;
+    color: var(--text-muted);
+}
+
+.form-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
 #add-agent-form input, #add-agent-form select {
     background: var(--bg-card);
     color: var(--text-primary);

--- a/public/styles.css
+++ b/public/styles.css
@@ -549,17 +549,18 @@ body {
     gap: 12px;
 }
 
-#add-agent-form input {
+#add-agent-form input, #add-agent-form select {
     background: var(--bg-card);
     color: var(--text-primary);
     border: 1px solid var(--border-subtle);
     border-radius: 6px;
     padding: 10px 14px;
     font-size: 14px;
+    height: 42px;
     transition: all 0.2s;
 }
 
-#add-agent-form input:focus {
+#add-agent-form input:focus, #add-agent-form select:focus {
     outline: none;
     border-color: var(--accent-teal);
     box-shadow: 0 0 0 2px rgba(77, 208, 225, 0.2);

--- a/server.js
+++ b/server.js
@@ -635,6 +635,9 @@ function setupNativeWindow() {
   w.bind('nativeGetAgents', (_w) => JSON.stringify(agents));
 
   w.bind('nativeAddAgent', (_w, name, role, emoji) => {
+    if (!name || !role) {
+      return JSON.stringify({ error: 'name and role are required' });
+    }
     const newAgent = { id: randomUUID(), name, role, emoji: sanitizeEmoji(emoji), status: 'IDLE', output: [], queue: [] };
     agents.push(newAgent);
     return JSON.stringify(agents);

--- a/server.js
+++ b/server.js
@@ -38,6 +38,16 @@ process.on('exit', (code) => {
   }
 });
 
+// ── Safe Emoji Allowlist ────────────────────────────────────────────────────
+const SAFE_EMOJIS = new Set([
+  '🤖', '🏗️', '⚛️', '⚙️', '🔬', '🎯', '🛡️', '🧠', '💡', '🔍',
+  '📊', '🚀', '🦊', '🐙', '🦉', '🎨', '📝', '⚡', '🔧', '🌐',
+]);
+
+function sanitizeEmoji(emoji) {
+  return SAFE_EMOJIS.has(emoji) ? emoji : '🤖';
+}
+
 // ── State ──────────────────────────────────────────────────────────────────
 let agents = [];
 let squadClient = null;
@@ -464,7 +474,7 @@ app.get('/api/agents', (_req, res) => {
 app.post('/api/agents', (req, res) => {
   const { name, role, emoji } = req.body;
   if (!name || !role) return res.status(400).json({ error: 'name and role are required' });
-  const newAgent = { id: randomUUID(), name, role, emoji: emoji || '🤖', status: 'IDLE', output: [], queue: [] };
+  const newAgent = { id: randomUUID(), name, role, emoji: sanitizeEmoji(emoji), status: 'IDLE', output: [], queue: [] };
   agents.push(newAgent);
   res.status(201).json(agents);
 });
@@ -625,7 +635,7 @@ function setupNativeWindow() {
   w.bind('nativeGetAgents', (_w) => JSON.stringify(agents));
 
   w.bind('nativeAddAgent', (_w, name, role, emoji) => {
-    const newAgent = { id: randomUUID(), name, role, emoji: emoji || '🤖', status: 'IDLE', output: [], queue: [] };
+    const newAgent = { id: randomUUID(), name, role, emoji: sanitizeEmoji(emoji), status: 'IDLE', output: [], queue: [] };
     agents.push(newAgent);
     return JSON.stringify(agents);
   });

--- a/server.js
+++ b/server.js
@@ -45,7 +45,9 @@ const SAFE_EMOJIS = new Set([
 ]);
 
 function sanitizeEmoji(emoji) {
-  return SAFE_EMOJIS.has(emoji) ? emoji : '🤖';
+  if (typeof emoji !== 'string') return '🤖';
+  const normalized = emoji.trim();
+  return SAFE_EMOJIS.has(normalized) ? normalized : '🤖';
 }
 
 // ── State ──────────────────────────────────────────────────────────────────

--- a/server.js
+++ b/server.js
@@ -70,6 +70,15 @@ function sanitizeEmoji(emoji) {
   return SAFE_EMOJIS.has(normalized) ? normalized : '🤖';
 }
 
+const MAX_AGENT_FIELD_LENGTH = 100;
+
+function validateAgentFields(name, role) {
+  if (typeof name !== 'string' || typeof role !== 'string') return 'name and role must be strings';
+  if (!name.trim() || !role.trim()) return 'name and role are required';
+  if (name.length > MAX_AGENT_FIELD_LENGTH || role.length > MAX_AGENT_FIELD_LENGTH) return `name and role must be ${MAX_AGENT_FIELD_LENGTH} characters or fewer`;
+  return null;
+}
+
 // ── State ──────────────────────────────────────────────────────────────────
 let agents = [];
 let squadClient = null;
@@ -499,7 +508,8 @@ app.get('/api/agents', (_req, res) => {
 
 app.post('/api/agents', (req, res) => {
   const { name, role, emoji } = req.body;
-  if (!name || !role) return res.status(400).json({ error: 'name and role are required' });
+  const validationError = validateAgentFields(name, role);
+  if (validationError) return res.status(400).json({ error: validationError });
   const newAgent = { id: randomUUID(), name, role, emoji: sanitizeEmoji(emoji), status: 'IDLE', output: [], queue: [] };
   agents.push(newAgent);
   res.status(201).json(agents);
@@ -665,9 +675,8 @@ function setupNativeWindow() {
   w.bind('nativeGetAgents', (_w) => JSON.stringify(agents));
 
   w.bind('nativeAddAgent', (_w, name, role, emoji) => {
-    if (!name || !role) {
-      return JSON.stringify({ error: 'name and role are required' });
-    }
+    const validationError = validateAgentFields(name, role);
+    if (validationError) return JSON.stringify({ error: validationError });
     const newAgent = { id: randomUUID(), name, role, emoji: sanitizeEmoji(emoji), status: 'IDLE', output: [], queue: [] };
     agents.push(newAgent);
     return JSON.stringify(agents);

--- a/server.js
+++ b/server.js
@@ -70,13 +70,16 @@ function sanitizeEmoji(emoji) {
   return SAFE_EMOJIS.has(normalized) ? normalized : '🤖';
 }
 
-const MAX_AGENT_FIELD_LENGTH = 100;
-
-function validateAgentFields(name, role) {
-  if (typeof name !== 'string' || typeof role !== 'string') return 'name and role must be strings';
-  if (!name.trim() || !role.trim()) return 'name and role are required';
-  if (name.length > MAX_AGENT_FIELD_LENGTH || role.length > MAX_AGENT_FIELD_LENGTH) return `name and role must be ${MAX_AGENT_FIELD_LENGTH} characters or fewer`;
-  return null;
+function sanitizeName(value) {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  const limited = trimmed.slice(0, 100);
+  return limited
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 // ── State ──────────────────────────────────────────────────────────────────
@@ -508,9 +511,10 @@ app.get('/api/agents', (_req, res) => {
 
 app.post('/api/agents', (req, res) => {
   const { name, role, emoji } = req.body;
-  const validationError = validateAgentFields(name, role);
-  if (validationError) return res.status(400).json({ error: validationError });
-  const newAgent = { id: randomUUID(), name, role, emoji: sanitizeEmoji(emoji), status: 'IDLE', output: [], queue: [] };
+  const sanitizedName = sanitizeName(name);
+  const sanitizedRole = sanitizeName(role);
+  if (!sanitizedName || !sanitizedRole) return res.status(400).json({ error: 'name and role are required' });
+  const newAgent = { id: randomUUID(), name: sanitizedName, role: sanitizedRole, emoji: sanitizeEmoji(emoji), status: 'IDLE', output: [], queue: [] };
   agents.push(newAgent);
   res.status(201).json(agents);
 });


### PR DESCRIPTION
This pull request updates how users select emojis when adding a new agent, ensures only a predefined set of safe emojis can be used, and makes related improvements to both the frontend and backend. The most important changes are grouped below:

**Frontend Improvements:**

* Replaced the free-text emoji input in the `<form id="add-agent-form">` in `public/index.html` with a dropdown `<select>` containing a curated list of emoji options, preventing users from entering arbitrary emojis.
* Updated the CSS in `public/styles.css` to style the new `<select>` element consistently with input fields, including focus states and sizing.

**Backend Validation and Security:**

* Introduced a `SAFE_EMOJIS` allowlist and a `sanitizeEmoji` function in `server.js` to ensure that only approved emojis are accepted when creating a new agent.
* Updated both the `/api/agents` POST endpoint and the `nativeAddAgent` handler in `server.js` to use `sanitizeEmoji`, ensuring only safe emojis are stored for agents regardless of the source. [[1]](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fL467-R477) [[2]](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fL628-R638)

**Cache Management:**

* Bumped the service worker cache version in `public/service-worker.js` from `v1` to `v3` to ensure users receive the latest changes to the app shell.